### PR TITLE
Update IO::Socket::SSL dependency to 1.54 - as reported here https://git...

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
     PREREQ_PM => {
 	'LWP::UserAgent' => '6.02',
 	'Net::HTTPS' => 6,
-	'IO::Socket::SSL' => "1.38",
+	'IO::Socket::SSL' => "1.54",
 	'Mozilla::CA' => "20110101",
     },
     META_MERGE => {


### PR DESCRIPTION
...hub.com/ranguard/libwww-perl/commit/3aac64c5d293dfe4c1b1f161fe3d0d02833f2a4e (but this might be an easier thing to merge as it's a separate repo)
