### PR TITLE
I had problems with 'make test' w/o Net::SSLeay 

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ WriteMakefile(
 	'Net::HTTPS' => 6,
 	'IO::Socket::SSL' => "1.54",
 	'Mozilla::CA' => "20110101",
+	'Net::SSLeay' => 0
     },
     META_MERGE => {
 	resources => {


### PR DESCRIPTION
The 'make test' has problem when module Net::SSLeay misses
I think it will be better to add as prerequisite
