### PR TITLE
Don't require Mozilla::CA

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,8 +14,7 @@ WriteMakefile(
     PREREQ_PM => {
 	'LWP::UserAgent' => '6.04',
 	'Net::HTTPS' => 6,
-	'IO::Socket::SSL' => "1.54",
-	'Mozilla::CA' => "20110101",
+	'IO::Socket::SSL' => "1.951",
     },
     META_MERGE => {
 	resources => {

--- a/README
+++ b/README
@@ -13,13 +13,6 @@ DESCRIPTION
     you don't use it directly. Once the module is installed LWP is able to
     access sites using HTTP over SSL/TLS.
 
-    If hostname verification is requested by LWP::UserAgent's `ssl_opts',
-    and neither `SSL_ca_file' nor `SSL_ca_path' is set, then `SSL_ca_file'
-    is implied to be the one provided by Mozilla::CA. If the Mozilla::CA
-    module isn't available SSL requests will fail. Either install this
-    module, set up an alternative `SSL_ca_file' or disable hostname
-    verification.
-
     This module used to be bundled with the libwww-perl, but it was
     unbundled in v6.02 in order to be able to declare its dependencies
     properly for the CPAN tool-chain. Applications that need https support
@@ -27,7 +20,7 @@ DESCRIPTION
     longer need to know what underlying modules to install.
 
 SEE ALSO
-    IO::Socket::SSL, Crypt::SSLeay, Mozilla::CA
+    IO::Socket::SSL, Crypt::SSLeay
 
 COPYRIGHT
     Copyright 1997-2011 Gisle Aas.

--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -22,29 +22,6 @@ sub _extra_sock_opts
     else {
 	$ssl_opts{SSL_verify_mode} = 0;
     }
-    if ($ssl_opts{SSL_verify_mode}) {
-	unless (exists $ssl_opts{SSL_ca_file} || exists $ssl_opts{SSL_ca_path}) {
-	    eval {
-		require Mozilla::CA;
-	    };
-	    if ($@) {
-		if ($@ =! /^Can't locate Mozilla\/CA\.pm/) {
-		    $@ = <<'EOT';
-Can't verify SSL peers without knowing which Certificate Authorities to trust
-
-This problem can be fixed by either setting the PERL_LWP_SSL_CA_FILE
-envirionment variable or by installing the Mozilla::CA module.
-
-To disable verification of SSL peers set the PERL_LWP_SSL_VERIFY_HOSTNAME
-envirionment variable to 0.  If you do this you can't be sure that you
-communicate with the expected peer.
-EOT
-		}
-		die $@;
-	    }
-	    $ssl_opts{SSL_ca_file} = Mozilla::CA::SSL_ca_file();
-	}
-    }
     $self->{ssl_opts} = \%ssl_opts;
     return (%ssl_opts, $self->SUPER::_extra_sock_opts);
 }


### PR DESCRIPTION
Hi!

IO::Socket::SSL 1.951 now automatically falls back to using the
system's root CA-certificates if no options are passed. Therefore
the workaround to use Mozilla::CA is no longer needed. So this
finally allows administrators to easily manage their root CAs
globally.
