### PR TITLE
Typo fix: envirionment =~ s/io/o/

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -33,10 +33,10 @@ sub _extra_sock_opts
 Can't verify SSL peers without knowing which Certificate Authorities to trust
 
 This problem can be fixed by either setting the PERL_LWP_SSL_CA_FILE
-envirionment variable or by installing the Mozilla::CA module.
+environment variable or by installing the Mozilla::CA module.
 
 To disable verification of SSL peers set the PERL_LWP_SSL_VERIFY_HOSTNAME
-envirionment variable to 0.  If you do this you can't be sure that you
+environment variable to 0.  If you do this you can't be sure that you
 communicate with the expected peer.
 EOT
 		}


### PR DESCRIPTION
Self-explanatory, I hope!
