### PR TITLE
Clarify how SSL_ca_path is passed

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -179,6 +179,14 @@ LWP::Protocol::https - Provide https support for LWP::UserAgent
 
   $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 1 });
   $res = $ua->get("https://www.example.com");
+  
+  # specify a CA path
+  $ua = LWP::UserAgent->new(
+      ssl_opts => { 
+          SSL_ca_path     => '/etc/ssl/certs', 
+          verify_hostname => 1, 
+      }
+  );
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
I had to have a quick look at the source to make sure that SSL_ca_path needed to be passed inside ssl_opts rather than on the same level.  Figured this could be made blatantly obvious via the SYNOPSIS.
