### PR TITLE
do not verify apache.org cert (RT #104150)

### DIFF
--- a/t/apache.t
+++ b/t/apache.t
@@ -5,7 +5,7 @@ use Test::More;
 
 use LWP::UserAgent;
 
-my $ua = LWP::UserAgent->new();
+my $ua = LWP::UserAgent->new( ssl_opts => {verify_hostname => 0} );
 plan skip_all => "Not online" unless $ua->is_online;
 
 plan tests => 5;
@@ -20,7 +20,6 @@ like($res->content, qr/Apache Software Foundation/);
 # test for RT #81948
 my $warn = '';
 $SIG{__WARN__} = sub { $warn = shift };
-$ua = LWP::UserAgent->new( ssl_opts => {verify_hostname => 0} );
 $res = $ua->simple_request(HTTP::Request->new(GET => "https://www.apache.org"));
 ok($res->is_success);
 is($warn, '', "no warning seen");


### PR DESCRIPTION
With some versions of openSSL (on OS X it appears) this test fails because the apache.org cert does not validate with IO::Socket::IP or IO::Socket::INET. There is no good reason to test cert validation with apache.org's cert here (it is prone to spontaneous failures like this), so this patch disables verify_hostname for the test.