### PR TITLE
Use Test::RequiresInternet to verify connectivity to internet and apache.org

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
 	'Net::HTTPS' => 6,
 	'IO::Socket::SSL' => "1.54",
 	'Mozilla::CA' => "20110101",
+	'Test::RequiresInternet' => 0,
     },
     META_MERGE => {
 	resources => {

--- a/t/apache.t
+++ b/t/apache.t
@@ -2,11 +2,11 @@
 
 use strict;
 use Test::More;
+use Test::RequiresInternet 'www.apache.org' => 443;
 
 use LWP::UserAgent;
 
 my $ua = LWP::UserAgent->new();
-plan skip_all => "Not online" unless $ua->is_online;
 
 plan tests => 5;
 


### PR DESCRIPTION
Test::RequiresInternet is a more reliable check, honors NO_NETWORK_TESTING, and can check specifically if apache.org's HTTPS port is reachable before attempting the test.