### PR TITLE
Use SSL_hostname instead of SSL_verifycn_name so that SNI works

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -152,7 +152,7 @@ if ( $Net::HTTPS::SSL_SOCKET_CLASS->can('start_SSL')) {
     *_upgrade_sock = sub {
 	my ($self,$sock,$url) = @_;
 	$sock = LWP::Protocol::https::Socket->start_SSL( $sock,
-	    SSL_verifycn_name => $url->host,
+	    SSL_hostname => $url->host,
 	    $self->_extra_sock_opts,
 	);
 	$@ = LWP::Protocol::https::Socket->errstr if ! $sock;


### PR DESCRIPTION
Currently LWP::Protocol::https does not work over a proxy when connecting to a server using SNI such as `admin.fraudfax.com`. The issue appears to be that when upgrading the socket, the module passes `SSL_verifycn_name` rather than `SSL_hostname`. The primary consequence of this [appears to be that the host is not used when setting up SNI](https://metacpan.org/source/SULLR/IO-Socket-SSL-2.016/lib/IO/Socket/SSL.pm#L604).
