### PR TITLE
Use warnings

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -1,6 +1,7 @@
 package LWP::Protocol::https;
 
 use strict;
+use warnings;
 our $VERSION = "6.06";
 
 require LWP::Protocol::http;


### PR DESCRIPTION
This is a trivial PR to use warnings in the module as recommended by [CPANTS](http://cpants.cpanauthors.org/dist/LWP-Protocol-https-6.06). There doesn't appear to be any particular reason not to use warnings for this module and it passes tests cleanly (and quietly) when warnings are used on my test systems.
