### PR TITLE
Upgrade Mozilla::CA dependency to 20150826

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ my %WriteMakefileArgs = (
                     'LWP::UserAgent' => '6.06',
                     'Net::HTTPS' => 6,
                     'IO::Socket::SSL' => "1.54",
-                    'Mozilla::CA' => "20110101",
+                    'Mozilla::CA' => "20150826",
                     'perl' => '5.008001',
                 },
             },


### PR DESCRIPTION
Because certificates are only useful if up to date.

See Mozilla's changelog:
https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt
