### PR TITLE
Fix operator when checking for Mozilla::CA error

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -29,7 +29,7 @@ sub _extra_sock_opts
 		require Mozilla::CA;
 	    };
 	    if ($@) {
-		if ($@ =! /^Can't locate Mozilla\/CA\.pm/) {
+		if ($@ =~ /^Can't locate Mozilla\/CA\.pm/) {
 		    $@ = <<'EOT';
 Can't verify SSL peers without knowing which Certificate Authorities to trust
 


### PR DESCRIPTION
I noticed a strange looking operator and figured it was a mistake.

I used this test to verify the change, but I'm not sure that you would want to add it to the dist:

```perl
#!/usr/bin/perl

use strict;
use warnings;
use Test::More;
use LWP::UserAgent;
use LWP::Protocol::https;

plan tests => 1;

{
  my $ua = LWP::UserAgent->new(
      ssl_opts => { verify_hostname => 1 }
  );
  local @INC; # so Mozilla::CA won't be found.
  local $_ = "Can't locate Mozilla/CA.pm";
  eval {
    LWP::Protocol::https->new(ua => $ua)->_extra_sock_opts;
  };
  like(
    $@,
    qr/Can't verify SSL peers without knowing which Certificate Authorities to trust/,
    'friendlier error message when missing Mozilla::CA'
  );
}
```