### PR TITLE
Adds coverage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /pm_to_blib
 .tidyall.d
 xx*
+
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ before_install:
   - source ~/travis-perl-helpers/init
   - build-perl
   - perl -V
+install:
+  - cpan-install --coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,24 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
+matrix:
+  include:
+    - perl: 5.24
+      env: COVERAGE=1   # enables coverage+coveralls reporting
+sudo: false
 before_install:
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init
   - build-perl
   - perl -V
+  - build-dist
+  - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
 install:
+  - cpan-install ExtUtils::MakeMaker --deps
   - cpan-install --coverage
+before_script:
+  -  coverage-setup
+script:
+  - prove -l -j$(test-jobs) $(test-files)   # parallel testing
+after_success:
+  - coverage-report

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author  = Gisle Aas <gisle@activestate.com>
 license = Perl_5
 main_module = lib/LWP/Protocol/https.pm
 copyright_holder = Gisle Aas
-copyright_year   = 1997-2016
+copyright_year   = 2017
 version = 6.06
 
 ; Gather stuff in


### PR DESCRIPTION
Following the example of @moose, but it's pretty much the same you pointed me to. For the time being, it prints [coverage in the logs](https://travis-ci.org/JJ/LWP-Protocol-https/jobs/236926038) (spoiler: not good) but I guess that if it finds a matching repo in coveralls.io, which you said you had set up, it should upload it there. Tell me if it does not work 