### PR TITLE
Make available the version of SSL/TLS protocol used in the connection

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -129,6 +129,9 @@ sub _get_sock_info
     my $self = shift;
     $self->SUPER::_get_sock_info(@_);
     my($res, $sock) = @_;
+    if ($sock->can('get_sslversion') and my $sslversion = $sock->get_sslversion) {
+        $res->header("Client-SSL-Version" => $sslversion);
+    }
     $res->header("Client-SSL-Cipher" => $sock->get_cipher);
     my $cert = $sock->get_peer_certificate;
     if ($cert) {


### PR DESCRIPTION
I have often used the extra response headers to troubleshoot a connection, e.g.:

```
Client-SSL-Cipher: ECDHE-RSA-AES128-GCM-SHA256
Client-SSL-Socket-Class: IO::Socket::SSL
```

but I also need to know the TLS version being used (1.2 or 1.3 in this case).

I didn't see a way to tell that, so figured adding the same kind of header for the version # would make sense.

Please let me know if there's already a way, or a better way to do this. Thanks!