### PR TITLE
Enable MultiHomed for IO::Socket::SSL

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -46,7 +46,7 @@ EOT
 	}
     }
     $self->{ssl_opts} = \%ssl_opts;
-    return (%ssl_opts, $self->SUPER::_extra_sock_opts);
+    return (%ssl_opts, MultiHomed => 1, $self->SUPER::_extra_sock_opts);
 }
 
 #------------------------------------------------------------


### PR DESCRIPTION
Automatically fall back to IPv4 if IPv6 doesn't work