### PR TITLE
Making it possible to use IPv6 in https call through https proxy environment (in case of using CONNECT method to create a tunnel)

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -48,7 +48,7 @@ This problem can be fixed by either setting the PERL_LWP_SSL_CA_FILE
 environment variable to the file where your trusted CA are, or by installing
 the Mozilla::CA module for set of commonly trusted CAs.
 
-To completly disable the verification that you talk to the correct SSL peer you
+To completely disable the verification that you talk to the correct SSL peer you
 can set SSL_verify_mode to 0 within ssl_opts.  But, if you do this you can't be
 sure that you communicate with the expected peer.
 EOT

--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -96,9 +96,12 @@ sub _get_sock_info
 if ( $Net::HTTPS::SSL_SOCKET_CLASS->can('start_SSL')) {
     *_upgrade_sock = sub {
 	my ($self,$sock,$url) = @_;
+    # SNI should be passed there only if it is not an IP address.
+    # Details: https://github.com/libwww-perl/libwww-perl/issues/449#issuecomment-1896175509
+	my $host = $url->host_port() =~ m/:|^[\d.]+$/s ? () : $url->host();
 	$sock = LWP::Protocol::https::Socket->start_SSL( $sock,
 	    SSL_verifycn_name => $url->host,
-	    SSL_hostname => $url->host,
+	    SSL_hostname => $host,
 	    $self->_extra_sock_opts,
 	);
 	$@ = LWP::Protocol::https::Socket->errstr if ! $sock;

--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -98,7 +98,7 @@ if ( $Net::HTTPS::SSL_SOCKET_CLASS->can('start_SSL')) {
 	my ($self,$sock,$url) = @_;
     # SNI should be passed there only if it is not an IP address.
     # Details: https://github.com/libwww-perl/libwww-perl/issues/449#issuecomment-1896175509
-	my $host = $url->host_port() =~ m/:|^[\d.]+$/s ? () : $url->host();
+	my $host = $url->host_port() =~ m/:|^[\d.]+$/s ? undef : $url->host();
 	$sock = LWP::Protocol::https::Socket->start_SSL( $sock,
 	    SSL_verifycn_name => $url->host,
 	    SSL_hostname => $host,


### PR DESCRIPTION
More details at https://github.com/libwww-perl/libwww-perl/issues/449