### PR TITLE
Fix ssl upgrade for regular host names

### DIFF
--- a/lib/LWP/Protocol/https.pm
+++ b/lib/LWP/Protocol/https.pm
@@ -98,7 +98,7 @@ if ( $Net::HTTPS::SSL_SOCKET_CLASS->can('start_SSL')) {
 	my ($self,$sock,$url) = @_;
     # SNI should be passed there only if it is not an IP address.
     # Details: https://github.com/libwww-perl/libwww-perl/issues/449#issuecomment-1896175509
-	my $host = $url->host_port() =~ m/:|^[\d.]+$/s ? undef : $url->host();
+	my $host = $url->host() =~ m/:|^[\d.]+$/s ? undef : $url->host();
 	$sock = LWP::Protocol::https::Socket->start_SSL( $sock,
 	    SSL_verifycn_name => $url->host,
 	    SSL_hostname => $host,


### PR DESCRIPTION
Due to a buggy string match, SSL_hostname is always undef: matching ":" in host_port, which always has a colon between the host and the port. This leads to "certificate verify failed" openssl error (observed along with a proxy negotiating TLVv1.3).

I suspect this is openssl trying to compare the hostname (which we do not pass) in the server certificate CN / SAN.

Fixes regression introduced in v6.12:

6e9101ba Making it possible to use IPv6 in https call...