### PR TITLE
Tune CI and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
+  groups:
+    major-updates:
+      patterns:
+        - "*"
+      update-types:
+        - "major"
+    minor-and-patch:
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.38
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v6
       - name: Run Tests
@@ -33,7 +33,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.38
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v6 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v7

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -10,6 +10,10 @@ on:
       - "*"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-job:
     name: Build distribution

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -109,9 +109,9 @@ jobs:
         with:
           name: build_dir
           path: .
-      - name: install deps using cpm
-        uses: perl-actions/install-with-cpm@v1
+      - uses: perl-actions/setup-cpm@v1
         with:
-          cpanfile: "cpanfile"
-          args: "--with-suggests --with-recommends --with-test"
+          version: compat
+      - name: install deps using cpm
+        run: cpm install -g --cpanfile cpanfile --with-suggests --with-recommends --with-test
       - run: prove -lr t


### PR DESCRIPTION
## Summary

Modernizes CI and dependabot config for this repo.

### Dependabot (`.github/dependabot.yml`)
- **Two groups** for the `github-actions` entry — `major-updates` (batches coordinated major bumps, e.g. `upload-artifact`/`download-artifact`, so they land atomically) and `minor-and-patch` (rolls routine bumps into one PR).
- **7-day cooldown** (`default-days: 7`) so PRs wait for broken releases to be yanked or patched first.

### CI workflow (`.github/workflows/dzil-build-and-test.yml`)
- Bump build + coverage containers to `perldocker/perl-tester:5.42`.
- Add a workflow-level `concurrency:` block to cancel superseded runs.
- Install deps with `perl-actions/setup-cpm@v1` (`version: compat`) + an explicit `cpm install` step, replacing the legacy `install-with-cpm` composite action.

Other CI transforms (fail-fast, matrix through 5.42, push-trigger restriction) were already in place. Pre-5.24 macOS/Windows Perls are **intentionally retained** — this is a foundational library and the matrix is mixed-OS, so older Perls stay covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)