### PR TITLE
Fix GH#96: remove undeclared Try::Tiny dep, add non-blocking blead CI

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -48,6 +48,23 @@ jobs:
         run: cpan-install-dist-deps && test-dist
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+  # Perl development version (blead). Informational only: a red X here means the
+  # dist broke on the upcoming Perl (see GH#96, where it failed to install on
+  # blead 5.45.1). Keep this OUT of the required status checks so it never
+  # blocks a merge -- we want the signal, not a gate.
+  blead-job:
+    name: Perl blead (devel, non-blocking)
+    needs: build-job
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:devel
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: build_dir
+          path: .
+      - name: Install deps and test on blead
+        run: cpan-install-dist-deps && test-dist
   test-job:
     needs: build-job
     runs-on: ${{ matrix.os }}

--- a/t/diag.t
+++ b/t/diag.t
@@ -10,7 +10,6 @@ use IO::Socket::SSL::Utils ();
 use Socket                 ();
 use Test::More import => [qw( diag done_testing pass subtest )];
 use Test::Needs;
-use Try::Tiny qw( try );
 
 subtest 'openssl' => sub {
     test_needs 'Capture::Tiny';
@@ -28,18 +27,20 @@ subtest 'openssl' => sub {
 
 subtest 'net_ssleay' => sub {
     test_needs 'Net::SSLeay';
-    try {
+    eval {
         diag(
             sprintf 'Net::SSLeay::OPENSSL_VERSION_NUMBER() 0x%08x',
             Net::SSLeay::OPENSSL_VERSION_NUMBER()
         );
-    };
-    try {
+        1;
+    } or diag("Net::SSLeay::OPENSSL_VERSION_NUMBER() unavailable: $@");
+    eval {
         diag(
             sprintf 'Net::SSLeay::LIBRESSL_VERSION_NUMBER() 0x%08x',
             Net::SSLeay::LIBRESSL_VERSION_NUMBER()
         );
-    };
+        1;
+    } or diag("Net::SSLeay::LIBRESSL_VERSION_NUMBER() unavailable: $@");
     pass('Net::SSLeay');
 };
 


### PR DESCRIPTION
Closes #96

## Problem
`t/diag.t` did `use Try::Tiny qw( try );` but `Try::Tiny` was never declared as a test prerequisite (not in `cpanfile`, `META.json`, or `Makefile.PL`).

On a freshly built perl that does not already have `Try::Tiny` installed — e.g. blead **5.45.1**, as reported via IRC by @tux — the CPAN toolchain does not pull it in, so `t/diag.t` dies at compile time:

```
Can't locate Try/Tiny.pm in @INC
BEGIN failed--compilation aborted at t/diag.t line 13.
```

`make test` then fails, so the distribution appears not to install. The stable CI matrix tops out at 5.42 and the `test-job` installs only the declared `cpanfile` deps, so nothing currently catches this on the upcoming Perl.

## Changes

**1. Remove the undeclared `Try::Tiny` dependency (`t/diag.t`)**
The two `try { ... }` blocks only swallowed exceptions around diagnostic `Net::SSLeay` version calls — no `catch`. A plain `eval { ...; 1 } or diag(...)` is equivalent, so this drops the dependency entirely rather than adding it to the prereqs. Fewer test deps keeps the suite installable on minimal/blead perls, which is the whole point of the report. (`Try::Tiny` was the only undeclared test prereq — audited all of `t/*.t`.)

**2. Add a non-blocking blead CI job (`.github/workflows/dzil-build-and-test.yml`)**
A container job on `perldocker/perl-tester:devel` (tracks the latest Perl development release) that installs the declared deps and runs the suite. It has **no** `continue-on-error`, so a break shows up as a visible red X — but it is meant to be kept **out of the required status checks** in branch protection, so blead breakage never blocks a merge. This is the early-warning signal the stable matrix couldn't give for #96.

## Testing
- Reproduced the exact symptom with a red-green cycle by hiding `Try::Tiny` via an `@INC` hook:
  - **RED** (original `t/diag.t`): exit 255, `BEGIN failed--compilation aborted`.
  - **GREEN** (this change): exit 0, `t/diag.t` passes; the `eval` guard still catches the `LIBRESSL_VERSION_NUMBER` die and continues.
- `t/diag.t` passes with `Try::Tiny` both present and absent.
- `perltidy` reports no changes; `perl -c` OK.
- `t/https_proxy.t` / `t/example.t` unchanged (need local sockets / internet unavailable in the dev sandbox; unaffected by this change).
- Workflow YAML validated (parses; blead job wired to `needs: build-job`, `devel` image, no `continue-on-error`). The blead job itself will run for real on this PR.

## Notes
- The project `perl-review` STANDARDS prefer `Try::Tiny` over `eval`; that preference is intentionally overridden here since the dependency itself is the cause of the install failure. Confirmed with the maintainer.
- Caveat on the blead job: `perl-tester:devel` is a "fat" image with many modules preinstalled, so it reliably catches genuine blead code/test breakage but may not catch a future *undeclared-prereq* regression the way a truly minimal perl would. It's the reliable signal available given this repo's container-based CI; a strict minimal-prereq blead check would need a from-scratch perl build.
